### PR TITLE
Removing the readmore link

### DIFF
--- a/blocks/news-carousel/news-carousel.js
+++ b/blocks/news-carousel/news-carousel.js
@@ -19,7 +19,6 @@ export default async function decorate(block) {
       <div class="slider-text">
         <h3><a href="${item.path}">${item['card-title']}</a></h3>
         <p>${item['card-description']}</p>
-        <a href="${item.path}">Read More</a> 
       </div>
     </div>
 `);


### PR DESCRIPTION
Removing a redundant link from the carrousel to increase the lighthouse score.

Test URLs:
- Before: https://main--investsec-revego--hlxsites.hlx.page/
- After: https://read-more--investsec-revego--hlxsites.hlx.page/
